### PR TITLE
Simplified version of core's concat, with the chunked-seq stuff removed

### DIFF
--- a/src/babbling/concat.clj
+++ b/src/babbling/concat.clj
@@ -5,10 +5,9 @@
  ([x] x)
  ([x y]
   (lazy-seq
-    (let [s (seq x)]
-      (if s
-        (cons (first s) (concat (rest s) y))
-        y))))
+    (if-let [s (seq x)]
+      (cons (first s) (concat (rest s) y))
+      y)))
   ([x y & others]
    (apply concat (concat x y) others))
 )

--- a/src/babbling/concat.clj
+++ b/src/babbling/concat.clj
@@ -8,6 +8,11 @@
     (if-let [s (seq x)]
       (cons (first s) (concat (rest s) y))
       y)))
-  ([x y & others]
-   (apply concat (concat x y) others))
-)
+  ([x y & zs]
+     (let [cat (fn cat [xys zs]
+                 (lazy-seq
+                   (if-let [xys (seq xys)]
+                       (cons (first xys) (cat (rest xys) zs))
+                       (when zs
+                         (cat (first zs) (next zs))))))]
+       (cat (concat x y) zs))))


### PR DESCRIPTION
Here I'm playing with a simplified version of concat, based on the version from clojure.core, with the chunked-seq code removed, and using if-let, to see how it's different from my previous version.

I think the main difference is that my version uses recursion (without using recur), so the main problem is space, not time.

But I can't say for sure, as this are my first babblings, so I need some expert advise :)
